### PR TITLE
feat: move background removal to first frame render

### DIFF
--- a/android/QuickStart/app/src/main/java/im/zego/aiagent/express/quickstart/video/VideoChatActivity.java
+++ b/android/QuickStart/app/src/main/java/im/zego/aiagent/express/quickstart/video/VideoChatActivity.java
@@ -346,7 +346,6 @@ public class VideoChatActivity extends AppCompatActivity {
                 @Override
                 public void onDigitalMobileStartSuccess() {
                     Log.i(TAG, "onDigitalMobileStartSuccess");
-                    digitalPic.setVisibility(View.GONE);
                 }
 
                 @Override
@@ -366,6 +365,7 @@ public class VideoChatActivity extends AppCompatActivity {
                     runOnUiThread(() -> {
                         Log.i(TAG, "onSurfaceFirstFrameDraw");
                         loadingView.setVisibility(View.GONE);
+                        digitalPic.setVisibility(View.GONE);
                     });
                 }
             });


### PR DESCRIPTION
- Removes the background image when the digital human's first frame is rendered, instead of on startup.
- This prevents a potential visual flash of the original background and improves initial loading perception.