### PR TITLE
docs: 更新 iOS 和 Web README，对齐 Android 结构

### DIFF
--- a/ios/README.md
+++ b/ios/README.md
@@ -4,243 +4,122 @@
 
 ## 概述
 
-ZEGO 实时互动 AI Agent（下文简称"互动AI"或"AI Agent"），通过接入SDK及服务端 API，即可快速实现用户与 AI（智能体）进行超低延迟的 IM 图文聊天、语音通话、数字人语音通话等互动能力，从而满足 AI 陪伴、AI 客服、AI 数字人直播等场景。 ZEGO AI Agent 支持自定义设置人设、音色、形象等，支持多家大语言模型（LLM）、文本转换语音服务（TTS），且并支持长期记忆、外挂知识库、模型精调，从而实现更完美的智能体。
+ZEGO 实时互动 AI Agent（下文简称"互动 AI"或"AI Agent"），通过接入 SDK 及服务端 API，即可快速实现用户与 AI（智能体）进行超低延迟的语音通话、数字人语音通话、播报数字人等互动能力。
 
-本文介绍如何跑通 iOS 平台的示例代码，连接到 AI Agent 测试业务服务，体验以下三种能力：
+本示例演示 iOS 端如何接入 AI Agent，包含三个场景入口：
 
-- **语音通话**：与 AI 智能体进行纯语音对话
-- **数字人视频通话**：与数字人进行双向音视频互动
-- **播报数字人**：单向观看数字人播报，支持主动下发 TTS 文本
+| 入口 | 类 | 说明 |
+| --- | --- | --- |
+| 语音通话 | `ZegoAIAgentAudioViewController` | 与 AI Agent 进行实时语音对话（双向语音） |
+| 数字人通话 | `ZegoAIAgentDigitalHumanViewController`（mode = Interactive） | 与数字人视频对话（双向音视频 + 数字人形象渲染） |
+| 播报数字人 | `ZegoAIAgentDigitalHumanViewController`（mode = LiveBroadcast） | 单向观看数字人播报，支持主动发送 TTS 文本 |
 
-⚠️ 在运行客户端前，请先启动[您的业务后台](https://github.com/ZEGOCLOUD/ai_agent_quick_start_server/tree/main)，分支需和客户端匹配
+> ⚠️ 运行客户端前，请先部署并启动 [业务后台示例](https://github.com/ZEGOCLOUD/ai_agent_quick_start_server)，且**后台所用的 AppID 必须与客户端一致**。
 
 ## 前提条件
 
-- 已在 [ZEGO 控制台](https://console.zego.im/) 创建项目，并申请有效的 AppID 和 AppSign，详情请参考 [控制台 - 项目信息](https://doc-zh.zego.im/article/12107)。
-- 已联系 ZEGO 技术支持开通数字人 PaaS 服务和相关接口的权限（语音通话场景无需此步）。
-- 已联系 ZEGO 技术支持创建数字人（数字人相关场景需要）。
-- 已联系 ZEGO 技术支持获取支持 AI 回声消除的 [ZEGO Express SDK](https://doc-zh.zego.im/article/196)，并集成到您的项目中。
+- 已在 [ZEGO 控制台](https://console.zego.im/) 创建项目，并获取有效的 `AppID`，详情请参考 [控制台 - 项目信息](https://doc-zh.zego.im/article/12107)。
+- 已联系 ZEGO 技术支持开通 AI Agent / 数字人相关服务权限。
+- 数字人场景需要已创建数字人形象，可获取到 `digital_human_id`。
+
+## 环境要求
+
+- Xcode 15 及以上
+- iOS 13.0 及以上
+- CocoaPods（用于安装依赖库）
+- 真机或模拟器，麦克风权限（语音通话 / 数字人通话场景需要）
 
 ## 跑通步骤
 
-1. 将 [ai_agent_quick_start](https://github.com/ZEGOCLOUD/ai_agent_quick_start)克隆或下载到本地
-2. 在文件管理器或者Finder中将`/ios/ai_agent_quickstart/aiagent/server/ZegoKey.template.m`重命名为`ZegoKey.m`
-3. 终端切换到`/ios`目录，执行`pod install`安装依赖库。在完成后，会生成`ai_agent_quickstart.xcworkspace`文件
-4. 用XCode打开`ai_agent_quickstart.xcworkspace`文件，运行项目
-5. 打开`/ios/ai_agent_quickstart/aiagent/server/ZegoKey.m`，填写`kZegoAppId`和`kBaseURL`
-    > - `kZegoAppId` 可在 [ZEGO 控制台](https://console.zego.im) 的**项目概览**中查看。⚠️注意：必须与业务后台部署使用的AppID保持一致。
-    >
-    > - `kBaseURL` 为您的业务后台地址，请参考 [业务后台示例代码](https://github.com/ZEGOCLOUD/ai_agent_quick_start_server)部署好业务后台后，即可获取
-    >
-    > - 如需体验**播报数字人**能力，还需额外填写 `kDigitalHumanId`（联系 ZEGO 技术支持获取）
-6. 在首页选择要体验的功能入口（语音通话 / 数字人视频通话 / 播报数字人）
+1. 将 [ai_agent_quick_start](https://github.com/ZEGOCLOUD/ai_agent_quick_start) 克隆或下载到本地。
+2. 在文件管理器或 Finder 中将 `ios/ai_agent_quickstart/aiagent/server/ZegoKey.template.m` 重命名为 `ZegoKey.m`。
+3. 终端切换到 `ios/` 目录，执行 `pod install` 安装依赖库。完成后会生成 `ai_agent_quickstart.xcworkspace` 文件。
+4. 用 Xcode 打开 `ai_agent_quickstart.xcworkspace`。
+5. 打开 `ios/ai_agent_quickstart/aiagent/server/ZegoKey.m`，**填入你自己的配置**：
+   - `kZegoAppId`：ZEGO 控制台获取的 AppID
+   - `kBaseURL`：你部署的业务后台地址，例如 `https://your-server.example.com`
+   - `kDigitalHumanId`：数字人形象 ID（数字人 / 播报数字人场景需要）
 
-## 关于示例代码的详细说明
+   > ⚠️ `kZegoAppId` 必须与业务后台部署使用的 AppID 保持一致。
 
-<details>
-<summary>点击查看详细说明</summary>
+6. 连接设备或选择模拟器，点击 Run 运行。
+7. 在首页选择对应入口体验：
+   - **StartAIAudioCall**：语音通话
+   - **StartDigitalHumanCall**：数字人通话（需授权麦克风权限）
+   - **StartLiveDigitalHuman**：播报数字人（单向观看，输入文本可让数字人播报）
 
-### 技术栈
-
-- 开发语言：Objective-C
-- 平台：iOS
-- 依赖库：Masonry（UI布局）、AVFoundation（音频处理）、ZegoDigitalMobile（数字人渲染）
-- 服务：ZEGO AI Agent服务、ZEGO Express SDK
-
-### 项目结构
+## 目录结构
 
 ```
-ai_agent_quickstart/
-├── AppDelegate.h/m           # 应用程序代理
-├── SceneDelegate.h/m         # 场景代理
-├── ZegoAIAgentHomeViewController.h/m   # 首页入口控制器（语音通话 / 数字人视频通话 / 播报数字人）
-├── aiagent/                  # AI Agent核心模块
-│   ├── audio/                # 音频相关模块
-│   │   ├── ZegoAIAgentAudioViewController.h/m     # 音频智能体对话视图控制器
-│   │   ├── ZegoAIAgentAudioEventHandler.h          # 音频事件处理协议
-│   │   └── subtitles/    # 字幕相关组件
-│   │       ├── ZegoAIAgentSubtitlesTableView.h/m        # 字幕视图
-│   │       ├── core/     # 字幕核心处理（颜色、定义）
-│   │       ├── views/    # 字幕UI组件（Cell、Label、Model）
-│   │       └── protocol/ # 字幕相关协议（事件、消息分发器、消息协议）
-│   ├── digital_human/        # 数字人相关模块
-│   │   ├── ZegoAIAgentDigitalHumanViewController.h/m  # 数字人视图控制器（含 Interactive / LiveBroadcast 两种模式）
-│   │   └── ZegoAIAgentDigitalHumanEventHandler.h      # 数字人事件处理协议
-│   └── server/               # 后台服务接口
-│       ├── ZegoAIAgentServiceAPI.h/m                # 服务API封装（音频 / 数字人 / 播报数字人）
-│       ├── ZegoKey.h/m                              # 密钥管理
-│       └── protocol/      # 后台服务协议
-│           ├── ZegoAIGetTokenRequest.h/m         # Token请求
-│           ├── ZegoAIGetTokenResponse.h/m        # Token回包
-│           └── ZegoAIServiceCommonResponse.h/m  # 通用回包
-└── libs/                     # 第三方库
-    ├── Express/              # ZEGO Express SDK
-    └── ZegoDigitalMobile/    # ZEGO 数字人SDK
+ios/ai_agent_quickstart/
+├── AppDelegate.h/m                     # 应用程序代理
+├── SceneDelegate.h/m                   # 场景代理（加载首页控制器）
+├── ZegoAIAgentHomeViewController.h/m   # 首页：三个场景入口按钮
+├── main.m                              # 程序入口
+└── aiagent/                            # AI Agent 核心模块
+    ├── audio/                          # 音频模块
+    │   ├── ZegoAIAgentAudioViewController.h/m     # 语音通话场景
+    │   ├── ZegoAIAgentAudioEventHandler.h          # 音频事件处理协议
+    │   └── subtitles/                             # 字幕组件
+    │       ├── ZegoAIAgentSubtitlesTableView.h/m  # 字幕列表视图
+    │       ├── core/                              # 字幕核心（颜色、定义）
+    │       ├── views/                             # 字幕 UI（Cell、Label、Model）
+    │       └── protocol/                          # 字幕协议（事件、消息分发）
+    ├── digital_human/                 # 数字人模块
+    │   ├── ZegoAIAgentDigitalHumanViewController.h/m  # 数字人场景（Interactive / LiveBroadcast 两种模式）
+    │   └── ZegoAIAgentDigitalHumanEventHandler.h      # 数字人事件处理协议
+    └── server/                        # 后台服务接口
+        ├── ZegoAIAgentServiceAPI.h/m               # 服务 API 封装（音频 / 数字人 / 播报 / TTS）
+        ├── ZegoKey.h/m                             # 密钥配置（需改这里）
+        └── protocol/                               # 请求/响应模型
+            ├── ZegoAIGetTokenRequest.h/m
+            ├── ZegoAIGetTokenResponse.h/m
+            └── ZegoAIServiceCommonResponse.h/m
 ```
 
-### 流程说明
+## 核心流程
 
-#### 应用启动流程
+以语音通话为例，接入流程如下（数字人 / 播报数字人同理）：
 
-1. 应用启动，初始化AppDelegate和SceneDelegate
-2. SceneDelegate 加载 `ZegoAIAgentHomeViewController` 作为根视图控制器，进入首页
-3. 用户在首页选择三种能力之一：
-   - **StartAIAudioCall** → 跳转 `ZegoAIAgentAudioViewController`（音频对话）
-   - **StartDigitalHumanCall** → 跳转 `ZegoAIAgentDigitalHumanViewController`（mode = Interactive，数字人视频通话）
-   - **StartLiveDigitalHuman** → 跳转 `ZegoAIAgentDigitalHumanViewController`（mode = LiveBroadcast，播报数字人）
-
-#### 音频对话流程
-
-```mermaid
-sequenceDiagram
-    participant User as 用户
-    participant AudioVC as ZegoAIAgentAudioViewController
-    participant ServiceAPI as ZegoAIAgentServiceAPI
-    participant BusinessServer as 业务后台服务
-    participant PassServer as AI服务
-    participant Express as ZEGO EXPRESS SDK
-
-    User->>AudioVC: 点击"开始对话"按钮
-    AudioVC->>AudioVC: 请求麦克风权限
-    AudioVC->>ServiceAPI:startAudioWithCompletion
-    ServiceAPI->>Express: 初始化引擎/进房/推流
-    Express-->>ServiceAPI: 成功
-    ServiceAPI->>BusinessServer: api/start
-    BusinessServer-->>ServiceAPI: 返回
-    ServiceAPI-->>AudioVC: 聊天开始成功
-    Express-->>ServiceAPI: onRoomStreamUpdate回调(流更新)
-    ServiceAPI->>Express: 开始拉流(订阅智能体流)
-
-    loop 实时对话过程
-        User->>Express: 说话
-        Express->>PassServer: 发送语音数据(ASR)
-        Express->>User: 播放AI回复
-    end
+```
+[ZegoAIAgentServiceAPI getTokenWithCompletion:]    GET  /api/zego-token
+        │
+        ▼
+初始化引擎 / 登录 Express 房间
+        │
+        ▼
+[startAudioWithCompletion:]                         POST /api/start
+        │                                            （数字人用 startDigitalHuman，播报用 startLiveDigitalHuman）
+        ▼
+推流 / 拉流，开始互动
+        │
+        ▼
+结束：[stopAudioWithCompletion:]                    POST /api/stop + 登出房间
 ```
 
-#### 数字人视频通话流程
+三个场景的差异：
 
-```mermaid
-sequenceDiagram
-    participant User as 用户
-    participant DigitalVC as ZegoAIAgentDigitalHumanViewController
-    participant ServiceAPI as ZegoAIAgentServiceAPI
-    participant BusinessServer as 业务后台服务
-    participant Express as ZEGO EXPRESS SDK
-    participant DigitalMobile as ZegoDigitalMobile
+- **语音通话 / 数字人通话**：需要推本地流（`user_stream_id`），请求启动接口时传 `user_id`、`user_stream_id`。
+- **播报数字人**：单向观看，不推流、不传 `user_id` / `user_stream_id`，额外支持 `[sendAgentInstanceTTSWithText:completion:]` 主动播报。
 
-    User->>DigitalVC: 进入数字人界面（mode=Interactive）
-    DigitalVC->>DigitalVC: 显示loading和静态图片
-    DigitalVC->>DigitalVC: 请求麦克风权限
-    DigitalVC->>ServiceAPI: startDigitalHumanWithCompletion
-    ServiceAPI->>BusinessServer: /api/start-digital-human
-    BusinessServer-->>ServiceAPI: 返回数字人配置
-    ServiceAPI->>Express: 初始化引擎/进房/推流
-    ServiceAPI->>Express: 启用自定义视频渲染
-    Express-->>ServiceAPI: 成功
-    ServiceAPI-->>DigitalVC: 数字人启动成功
+## 依赖说明
 
-    DigitalVC->>DigitalMobile: 创建数字人实例
-    DigitalVC->>DigitalMobile: start(配置)
-    DigitalVC->>DigitalMobile: attach(previewView)
+服务接口与引擎操作已分层封装：
 
-    Express-->>ServiceAPI: onRoomStreamUpdate(智能体流)
-    ServiceAPI->>Express: 开始拉流
-    Express-->>DigitalVC: onRemoteVideoFrameRawData
-    DigitalVC->>DigitalMobile: 传递视频帧数据
-    Express-->>DigitalVC: onPlayerSyncRecvSEI
-    DigitalVC->>DigitalMobile: 传递SEI数据
+- `ZegoAIAgentServiceAPI`：业务后台接口封装（单例），集中提供 `startAudio` / `stopAudio` / `startDigitalHuman` / `stopDigitalHuman` / `startLiveDigitalHuman` / `stopLiveDigitalHuman` / `sendAgentInstanceTTS` / `getToken` / `ensureLogoutRoom` 等方法。
+- `ZegoAIAgentAudioViewController`：语音通话场景控制器，处理用户交互、权限请求和音频流程管理。
+- `ZegoAIAgentDigitalHumanViewController`：数字人场景控制器，通过 `mode` 属性区分 `Interactive`（双向通话）和 `LiveBroadcast`（单向播报）两种模式。
+- `ZegoAIAgentSubtitlesTableView`：字幕显示组件，实时展示对话内容（用户输入和 AI 回复）。
+- `ZegoKey`：配置类，通过 `kZegoAppId`、`kBaseURL`、`kDigitalHumanId` 等常量集中管理接入参数。
 
-    DigitalMobile-->>DigitalVC: onSurfaceFirstFrameDraw
-    DigitalVC->>DigitalVC: 隐藏loading和静态图片
+## 注意事项
 
-    loop 实时对话过程
-        User->>Express: 说话
-        Express->>BusinessServer: 语音数据处理
-        BusinessServer->>DigitalMobile: 数字人动画数据
-        DigitalMobile->>DigitalVC: 渲染数字人视频
-    end
-```
+- `ZegoKey.m` 中的 `kZegoAppId` 必须与业务后台使用的 AppID 一致，否则登录房间会失败。
+- `kBaseURL` 不要带末尾斜杠，代码内部会拼接路径。
+- `kDigitalHumanId` 需使用你账号下有效的数字人 ID，示例中的默认值仅供格式参考。
+- 语音通话 / 数字人通话需要麦克风权限；播报数字人为单向观看，无需麦克风。
+- 首次运行前必须先执行 `pod install`，用 `xcworkspace` 打开而非 `xcodeproj`。
 
-#### 播报数字人流程
+## 联系与支持
 
-```mermaid
-sequenceDiagram
-    participant User as 用户
-    participant DigitalVC as ZegoAIAgentDigitalHumanViewController
-    participant ServiceAPI as ZegoAIAgentServiceAPI
-    participant BusinessServer as 业务后台服务
-    participant Express as ZEGO EXPRESS SDK
-    participant DigitalMobile as ZegoDigitalMobile
-
-    User->>DigitalVC: 进入播报数字人界面（mode=LiveBroadcast）
-    DigitalVC->>DigitalVC: 显示loading和静态图片
-    Note over DigitalVC: 无需麦克风权限
-    DigitalVC->>ServiceAPI: startLiveDigitalHumanWithCompletion
-    ServiceAPI->>BusinessServer: /api/start-live-digital-human
-    BusinessServer-->>ServiceAPI: 返回数字人配置（agent_instance_id）
-    ServiceAPI->>Express: 初始化引擎/进房（不推本地流）
-    ServiceAPI->>Express: 启用自定义视频渲染
-    Express-->>ServiceAPI: 成功
-    ServiceAPI-->>DigitalVC: 启动成功
-
-    DigitalVC->>DigitalMobile: 创建数字人实例/start/attach
-    Express-->>DigitalVC: 推送视频帧 + SEI 给数字人 SDK
-    DigitalMobile-->>DigitalVC: onSurfaceFirstFrameDraw
-    DigitalVC->>DigitalVC: 隐藏loading和静态图片
-
-    User->>DigitalVC: 输入播报文本并点击发送
-    DigitalVC->>ServiceAPI: sendAgentInstanceTTSWithText:completion:
-    ServiceAPI->>BusinessServer: /api/send-agent-instance-tts
-    BusinessServer-->>ServiceAPI: 返回
-    ServiceAPI-->>DigitalVC: 播报请求已提交
-    BusinessServer->>Express: 数字人驱动数据
-    Express->>User: 播放数字人画面与声音
-```
-
-### 主要组件说明
-
-#### ZegoAIAgentServiceAPI
-
-提供与ZEGO AI服务交互的接口，包括初始化、创建智能体实例、开始聊天和结束聊天。
-
-**核心方法**
-
-- `startAudioWithCompletion:` / `stopAudioWithCompletion:` - 开始/停止音频对话
-- `startDigitalHumanWithCompletion:` / `stopDigitalHumanWithCompletion:` - 开始/停止数字人视频通话
-- `startLiveDigitalHumanWithCompletion:` / `stopLiveDigitalHumanWithCompletion:` - 开始/停止播报数字人
-- `sendAgentInstanceTTSWithText:completion:` - 向播报数字人下发 TTS 文本
-- `getTokenWithCompletion:` - 获取 Token
-- `ensureLogoutRoom` - 幂等退出 RTC 房间（兜底）
-
-#### ZegoAIAgentHomeViewController
-
-首页入口控制器，提供三种 AI 能力的导航按钮：语音通话、数字人视频通话、播报数字人。应用启动后直接进入本界面。
-
-#### ZegoAIAgentAudioViewController
-
-音频对话主界面控制器，负责处理用户交互、权限请求和音频流程管理。从首页 `StartAIAudioCall` 入口跳转。
-
-#### ZegoAIAgentDigitalHumanViewController
-
-数字人对话界面控制器，负责数字人视频渲染、音频交互和生命周期管理。通过 `mode` 属性区分两种形态：
-
-- `ZegoAIAgentDigitalHumanModeInteractive` - 数字人视频通话（双向音视频）
-- `ZegoAIAgentDigitalHumanModeLiveBroadcast` - 播报数字人（单向观看 + 主动 TTS）
-
-**核心功能**
-- 静态图片加载和显示(加载时占位)
-- 数字人视频流渲染
-- 音频权限管理（播报模式无需）
-- Loading状态管理
-- 视频帧数据和SEI数据处理
-- 主动 TTS 文本下发（仅播报模式）
-
-#### ZegoAIAgentSubtitlesTableView
-
-字幕显示组件，实现对话内容的实时显示，包括用户输入和AI回复。可通过主界面subtitles tab展开/收起。
-
-#### ZegoKey
-
-调试配置类，通过 `kZegoAppId`、`kBaseURL`、`kDigitalHumanId` 等常量集中管理接入参数。
-</details>
+如有任何问题，请联系 ZEGO 技术支持或访问 [开发者中心](https://docs.zegocloud.com/) 获取更多信息。

--- a/web/README.md
+++ b/web/README.md
@@ -4,71 +4,129 @@
 
 ## 概述
 
-ZEGO 实时互动 AI Agent（下文简称"互动AI"或"AI Agent"），通过接入SDK及服务端 API，即可快速实现用户与 AI（智能体）进行超低延迟的 IM 图文聊天、语音通话、数字人语音通话等互动能力，从而满足 AI 陪伴、AI 客服、AI 数字人直播等场景。 ZEGO AI Agent 支持自定义设置人设、音色、形象等，支持多家大语言模型（LLM）、文本转换语音服务（TTS），且并支持长期记忆、外挂知识库、模型精调，从而实现更完美的智能体。
+ZEGO 实时互动 AI Agent（下文简称"互动 AI"或"AI Agent"），通过接入 SDK 及服务端 API，即可快速实现用户与 AI（智能体）进行超低延迟的语音通话、数字人语音通话、播报数字人等互动能力。
 
-本文介绍如何跑通 iOS 平台的示例代码，连接到 AI Agent 测试业务服务，实现与数字人进行语音对话。
+本示例演示 Web 端如何接入 AI Agent，包含三个场景入口：
+
+| 入口 | 组件 / 函数 | 说明 |
+| --- | --- | --- |
+| 语音通话 | `Chat.vue` → `handleLogin('normal')` | 与 AI Agent 进行实时语音对话（双向语音） |
+| 数字人通话 | `Chat.vue` → `handleLogin('digitalHuman')` | 与数字人视频对话（双向音视频 + 数字人形象渲染） |
+| 播报数字人 | `Chat.vue` → `handleLogin('liveDigitalHuman')` | 单向观看数字人播报，支持主动发送 TTS 文本 |
+
+> ⚠️ 运行客户端前，请先部署并启动 [业务后台示例](https://github.com/ZEGOCLOUD/ai_agent_quick_start_server)，且**后台所用的 AppID 必须与客户端一致**。
 
 ## 前提条件
 
-- 已在 [ZEGO 控制台](https://console.zego.im/) 创建项目，并申请有效的 `AppID` 和 `Server URL`，详情请参考 [控制台 - 项目信息](https://doc-zh.zego.im/article/12107)。
-- 已联系 ZEGO 技术支持开通数字人 API 服务和相关接口的权限。
-- 已联系 ZEGO 技术支持创建数字人。
+- 已在 [ZEGO 控制台](https://console.zego.im/) 创建项目，并获取有效的 `AppID` 和 `Server URL`，详情请参考 [控制台 - 项目信息](https://doc-zh.zego.im/article/12107)。
+- 已联系 ZEGO 技术支持开通 AI Agent / 数字人相关服务权限。
+- 数字人场景需要已创建数字人形象，可获取到 `digital_human_id`。
 
 ## 环境要求
 
-- 现代浏览器（支持 WebRTC）
-- 麦克风权限
-- ZEGO 账号和 AppID（从 ZEGO 控制台获取）
+- Node.js >= 16.14.0
+- pnpm（推荐）或 npm
+- 现代浏览器（支持 WebRTC，推荐 Chrome）
+- 麦克风权限（语音通话 / 数字人通话场景需要）
 
 ## 跑通步骤
-1. 将 [ai_agent_quick_start](https://github.com/ZEGOCLOUD/ai_agent_quick_start)克隆或下载到本地
-2. 终端切换到 `/web` 目录，执行`pnpm install`安装依赖
-3. 将 `.env.example` 复制为 `.env`，并修改其中的配置项
-    > - `VITE_ZEGO_APP_ID`(基本信息的`AppID`) 和 `VITE_ZEGO_SERVER`(配置信息的`Server 地址`) 可在 [ZEGO 控制台](https://console.zego.im) 的**项目概览**中查看。⚠️注意：必须与业务后台部署使用的AppID保持一致。
-    >
-    > <img width="3840" height="1916" alt="Image" src="https://github.com/user-attachments/assets/8c7d021f-57fb-43a0-9389-77109f444bb8" />
-    >
-    > - `VITE_APP_BASE_URL` 为您的业务后台地址，请参考 [业务后台示例代码](https://github.com/ZEGOCLOUD/ai_agent_quick_start_server)部署好业务后台后，即可获取
 
-4. 执行 `pnpm dev` 启动项目
-5. 浏览器访问 `http://localhost:5173` 即可开始体验
+1. 将 [ai_agent_quick_start](https://github.com/ZEGOCLOUD/ai_agent_quick_start) 克隆或下载到本地。
+2. 终端切换到 `web/` 目录，执行 `pnpm install` 安装依赖。
+3. 将 `.env.example` 复制为 `.env`，**填入你自己的配置**：
+   - `VITE_ZEGO_APP_ID`：ZEGO 控制台获取的 AppID
+   - `VITE_ZEGO_SERVER`：ZEGO 控制台配置信息中的 Server 地址
+   - `VITE_APP_BASE_URL`：你部署的业务后台地址，例如 `https://your-server.example.com`
+   - `VITE_DIGITAL_HUMAN_ID`：数字人形象 ID（数字人 / 播报数字人场景需要）
 
-## 关于示例代码的详细说明
+   > ⚠️ `VITE_ZEGO_APP_ID` 必须与业务后台部署使用的 AppID 保持一致。
 
-<details>
-<summary>点击查看详细说明</summary>
+4. 执行 `pnpm dev` 启动项目。
+5. 浏览器访问 `http://localhost:5173`，选择对应入口体验：
+   - **Start AI Audio Call**：语音通话
+   - **Start Digital Human Call**：数字人通话（需授权麦克风权限）
+   - **Start Live Digital Human**：播报数字人（单向观看，输入文本可让数字人播报）
 
-### 环境变量可选配置项
+## 目录结构
 
-```bash
-# 数字人配置（如果不使用数字人功能可以保持默认值）
-VITE_DIGITAL_HUMAN_ID=20be9bfb-ef6b-4d63-8c3b-1f20077599c5
-VITE_CONFIG_ID=web
-
-# 开发配置
-VITE_DEBUG=true                           # 是否开启调试模式
-VITE_LOG_LEVEL=debug                      # 日志级别
-VITE_API_TIMEOUT=30000                    # API 请求超时时间
+```
+web/
+├── .env.example                        # 环境变量模板（需复制为 .env 并填写配置）
+├── index.html                          # HTML 入口
+├── package.json                        # 依赖管理
+├── vite.config.ts                      # Vite 构建配置
+├── tsconfig.json                       # TypeScript 配置
+└── src/
+    ├── main.ts                         # 应用入口
+    ├── App.vue                         # 根组件（包裹 ErrorBoundary + Chat）
+    ├── config.ts                       # 配置管理（读取环境变量并校验）
+    ├── api/
+    │   └── agent.ts                    # 业务后台接口封装（Token / Start / Stop / TTS）
+    ├── components/
+    │   ├── Chat.vue                    # 主界面：三个场景入口按钮 + 房间信息 + TTS 面板
+    │   ├── ChatMessage.vue             # 聊天消息列表组件
+    │   ├── RemoteSteamView.vue         # 远程流容器组件（数字人形象展示）
+    │   └── ErrorBoundary.vue           # 错误边界组件
+    ├── hooks/
+    │   ├── useRoom.ts                  # 房间逻辑（SDK 初始化 / 登录 / 推拉流 / 退出）
+    │   └── useChat.ts                  # 聊天逻辑（消息收发 / 字幕）
+    ├── solution/
+    │   └── ExpressManager.ts           # ZegoExpressEngine 封装（单例）
+    ├── types/
+    │   ├── enum.ts                     # 枚举定义
+    │   └── http.ts                     # HTTP 类型定义
+    ├── utils/
+    │   ├── http.ts                     # HTTP 请求封装（GET / POST）
+    │   ├── config-checker.ts           # 配置检查工具
+    │   ├── error-handler.ts            # 统一错误处理
+    │   └── logger.ts                   # 日志工具
+    └── assets/
+        └── vue.svg                     # 静态资源
 ```
 
+## 核心流程
 
-### 目录结构
+以语音通话为例，接入流程如下（数字人 / 播报数字人同理）：
+
 ```
-├── lib                 # 第三方库
-└── src
-    ├── api
-    │   └── agent       # AI Agent API
-    ├── components
-    │   ├── VoiceChat  # 语音聊天组件
-    │   ├── ChatMessage # 聊天消息组件
-    │   └── RemoteSteamView # 远程流容器组件
-    ├── hooks
-    │   └── useChat     # 聊天相关的 hooks
-    │   └── useRoom     # 房间相关的 hooks
-    ├── solution
-    │   └── ExpressManager # Express SDK 管理类
-    ├── utils
-    │   └── http        # http 请求工具
-    └── config          # 配置文件
+GetZegoToken()                GET  /api/zego-token
+        │
+        ▼
+ExpressManager.loginRoom()    登录 Express 房间
+        │
+        ▼
+Start()                       POST /api/start（数字人用 StartDigitalHuman，播报用 StartLiveDigitalHuman）
+        │
+        ▼
+推流 / 拉流，开始互动
+        │
+        ▼
+结束：Stop()                  POST /api/stop + 登出房间
 ```
-</details>
+
+三个场景的差异：
+
+- **语音通话 / 数字人通话**：需要推本地流（`user_stream_id`），请求启动接口时传 `user_id`、`user_stream_id`。
+- **播报数字人**：单向观看，不推流、不传 `user_id` / `user_stream_id`，额外支持 `SendAgentInstanceTTS()` 主动播报。
+
+## 依赖说明
+
+网络请求与引擎操作已分层封装，自底向上：
+
+- `utils/http.ts`：HTTP 底层封装，提供 GET / POST，统一处理响应。
+- `api/agent.ts`：业务后台接口封装，集中定义所有接口路径，并提供语义化方法（`GetZegoToken` / `Start` / `StartDigitalHuman` / `StartLiveDigitalHuman` / `SendAgentInstanceTTS` / `Stop`）。
+- `solution/ExpressManager.ts`：ZegoExpressEngine 单例封装，提供引擎初始化、登录房间、推拉流、音频流创建等能力。
+- `hooks/useRoom.ts`：房间逻辑 Hook，编排 SDK 初始化 → 获取 Token → 登录房间 → 推流 → 启动 Agent 的完整流程。
+- `hooks/useChat.ts`：聊天逻辑 Hook，处理消息收发和字幕展示。
+
+## 注意事项
+
+- `.env` 中的 `VITE_ZEGO_APP_ID` 必须与业务后台使用的 AppID 一致，否则登录房间会失败。
+- `VITE_APP_BASE_URL` 不要带末尾斜杠，代码内部会拼接路径。
+- `VITE_DIGITAL_HUMAN_ID` 需使用你账号下有效的数字人 ID，示例中的默认值仅供格式参考。
+- 语音通话 / 数字人通话需要麦克风权限；播报数字人为单向观看，无需麦克风。
+- 浏览器需支持 WebRTC，推荐使用最新版 Chrome。
+
+## 联系与支持
+
+如有任何问题，请联系 ZEGO 技术支持或访问 [开发者中心](https://docs.zegocloud.com/) 获取更多信息。


### PR DESCRIPTION
## 改动说明

将 iOS 和 Web 平台的 README 更新为与 Android README 一致的结构，同时基于最新代码修正过时内容。

### 主要改动

**iOS README**：
- 概述：精简营销性描述，新增三场景入口表格（对齐 Android 格式）
- 前提条件：去掉已废弃的 AppSign，去掉「获取支持 AI 回声消除的 SDK」的误导性描述
- 环境要求：新增（之前完全没有）
- 目录结构：精简注释，去掉 libs/ 目录（第三方库不应出现在示例文档中）
- 核心流程：用 ASCII 流程图替换三个 mermaid 时序图（与 Android 风格一致）
- 依赖说明：精简为分层说明，去掉冗长的方法列表
- 注意事项：新增
- 去掉整个 `<details>` 折叠块，信息不再藏起来

**Web README**：
- 概述：重写描述，新增三场景入口表格
- 目录结构：修正不存在的 VoiceChat 组件为实际文件（Chat.vue / ChatMessage.vue / RemoteSteamView.vue / ErrorBoundary.vue）
- 核心流程：新增 ASCII 流程图
- 依赖说明：新增分层架构说明
- 注意事项：新增
- 去掉 `<details>` 折叠块

### 统计
- 202 行新增，265 行删除（净减 63 行，内容更精炼但信息更全）

### 不涉及
- Android / Flutter / miniprogram README 未改动
- 代码逻辑未改动